### PR TITLE
dom-text-support

### DIFF
--- a/src/accordion/Accordion.js
+++ b/src/accordion/Accordion.js
@@ -15,7 +15,7 @@ _ACCORDION_OPTIONS = {
 _ADD_ACCORDION_OPTIONS = {
   toggleText: 'Details',
   toggleElement: 'span',
-  contentText: 'Contents',
+  content: 'Contents',
   classes: 'accordion-standard'
 };
 
@@ -103,7 +103,19 @@ var Accordion = function (options) {
 
     content = document.createElement('div');
     content.className = _ACCORDION_CONTENT;
-    content.innerHTML = options.contentText;
+
+    // Support legacy "contentText" if still present, but prefert "content"
+    if (options.contentText) {
+      content.innerHTML = options.contentText;
+    } else {
+      // Check if string content or DOM content
+      if (typeof options.content === 'string') {
+        content.innerHTML = options.content;
+      } else {
+        content.appendChild(options.content);
+      }
+    }
+
     accordion.appendChild(content);
 
     _el.appendChild(accordion);


### PR DESCRIPTION
Deprecate contentText. Prefer new content option, but still support contentText for legacy reasons. Change is backward compatible. New content option can be either a string or DOM element. DOM is generally preferred.