### PR TITLE
animate the expanding and collapsing of the accordion

### DIFF
--- a/src/accordion/Accordion.scss
+++ b/src/accordion/Accordion.scss
@@ -8,7 +8,7 @@ $accordion-background-color: #f4f4f4;
   display: block;
   margin: 1em 0 0;
   overflow: hidden;
-  padding: 0.75em 16px;
+  padding: 0.75em 1em 0.7em 0;
   text-overflow: ellipsis;
   white-space: nowrap;
 
@@ -18,9 +18,9 @@ $accordion-background-color: #f4f4f4;
     font-family: 'Material Icons';
     font-size: 1.2em;
     line-height: 1;
-    padding-right: 16px;
-    text-align: center;
+    padding: 0 1em;
     vertical-align: sub;
+    transition: transform 0.5s ease;
   }
 
   &:hover {
@@ -32,22 +32,26 @@ $accordion-background-color: #f4f4f4;
   border-bottom: 1px solid $accordion-border-color;
   border-left: 1px solid $accordion-border-color;
   border-right: 1px solid $accordion-border-color;
-  padding: 1px 1em 1em;
+  padding: 0 1em;
+  max-height: 30em;
+  overflow: scroll;
+  transition: max-height 0.5s cubic-bezier(1, 0, 0, 1);
 
   > :last-child {
-    margin-bottom: 0;
+    margin-bottom: 1em;
   }
 }
 
 .accordion-closed {
 
   > .accordion-toggle:before {
-    content: '\e5cf';
-    font-family: 'Material Icons';
+    transform: rotate(180deg);
   }
 
   > .accordion-content {
-    display: none;
+    border-bottom: 0;
+    max-height: 0;
+    overflow: hidden;
   }
 }
 
@@ -87,8 +91,8 @@ $accordion-background-color: #f4f4f4;
       font-size: 1.2em;
       padding: 0;
       position: static;
-      text-align: left;
-      width: 1.5em;
+      text-align: center;
+      width: 2em;
     }
 
     &:hover {


### PR DESCRIPTION
This animates the the expanding/collapsing of the accordion window. It also animates the caret between its expanded/collapsed state. 

To do this with css you have to animate on the `max-height` property. However, this means that I have set a `max-height: 30em;`. If people don't like this it can be changed or not merged, but I like how now the max-height works with our content. For instance, on the event pages this means that the download list doesn't expand and push the footer content out of view. Also, the 30em is a size that fits on an iphone 6 screen (it feels like a good size). 